### PR TITLE
Add pedsnet v2 schema files

### DIFF
--- a/pedsnet/v2/schema/concept_class.csv
+++ b/pedsnet/v2/schema/concept_class.csv
@@ -1,4 +1,4 @@
 model,version,table,field,type,length,precision,scale,default
-pedsnet,v2,concept_class,concept_class_concept_id,string,20,,,
-pedsnet,v2,concept_class,concept_class_id,string,255,,,
-pedsnet,v2,concept_class,concept_class_name,integer,,,,
+pedsnet,v2,concept_class,concept_class_concept_id,integer,,,,
+pedsnet,v2,concept_class,concept_class_id,string,20,,,
+pedsnet,v2,concept_class,concept_class_name,string,255,,,

--- a/pedsnet/v2/schema/concept_relationship.csv
+++ b/pedsnet/v2/schema/concept_relationship.csv
@@ -1,0 +1,7 @@
+model,version,table,field,type,length,precision,scale,default
+pedsnet,v2,concept_relationship,concept_id_1,integer,,,,
+pedsnet,v2,concept_relationship,concept_id_2,integer,,,,
+pedsnet,v2,concept_relationship,invalid_reason,string,1,,,
+pedsnet,v2,concept_relationship,relationship_id,string,20,,,
+pedsnet,v2,concept_relationship,valid_end_date,date,,,,
+pedsnet,v2,concept_relationship,valid_start_date,date,,,,

--- a/pedsnet/v2/schema/domain.csv
+++ b/pedsnet/v2/schema/domain.csv
@@ -1,0 +1,4 @@
+model,version,table,field,type,length,precision,scale,default
+pedsnet,v2,domain,domain_concept_id,integer,,,,
+pedsnet,v2,domain,domain_id,string,20,,,
+pedsnet,v2,domain,domain_name,string,255,,,

--- a/pedsnet/v2/schema/relationship.csv
+++ b/pedsnet/v2/schema/relationship.csv
@@ -1,0 +1,7 @@
+model,version,table,field,type,length,precision,scale,default
+pedsnet,v2,relationship,defines_ancestry,string,1,,,
+pedsnet,v2,relationship,is_hierarchical,string,1,,,
+pedsnet,v2,relationship,relationship_concept_id,integer,,,,
+pedsnet,v2,relationship,relationship_id,string,20,,,
+pedsnet,v2,relationship,relationship_name,string,255,,,
+pedsnet,v2,relationship,reverse_relationship_id,string,20,,,


### PR DESCRIPTION
Add schema files for pedsnet v2 domain, relationship, and
concept_relationship tables. Fix the schema file for pedsnet v2
concept_class table.

Fixes #65

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>