### PR TITLE
Remove i2b2_pedsnet v2 pk_i2b2

### DIFF
--- a/i2b2/i2b2_pedsnet/v2/data/constraints/primary_keys.csv
+++ b/i2b2/i2b2_pedsnet/v2/data/constraints/primary_keys.csv
@@ -8,7 +8,6 @@ i2b2_pedsnet,v2,primary key,pk_observation_fact,observation_fact,instance_num
 i2b2_pedsnet,v2,primary key,pk_observation_fact,observation_fact,provider_id
 i2b2_pedsnet,v2,primary key,pk_concept_dimension,concept_dimension,concept_path
 i2b2_pedsnet,v2,primary key,pk_patient_dimension,patient_dimension,patient_num
-i2b2_pedsnet,v2,primary key,pk_i2b2,i2b2,id
 i2b2_pedsnet,v2,primary key,pk_visit_dimension,visit_dimension,encounter_num
 i2b2_pedsnet,v2,primary key,pk_visit_dimension,visit_dimension,patient_num
 i2b2_pedsnet,v2,primary key,pk_provider_dimension,provider_dimension,provider_path

--- a/i2b2/i2b2_pedsnet/v2/metadata/constraints/primary_keys.csv
+++ b/i2b2/i2b2_pedsnet/v2/metadata/constraints/primary_keys.csv
@@ -1,2 +1,0 @@
-model,version,type,name,table,field
-i2b2_pedsnet,v2,primary key,pk_i2b2,i2b2,id

--- a/pedsnet/v2/schema/fact_relationship.csv
+++ b/pedsnet/v2/schema/fact_relationship.csv
@@ -1,6 +1,6 @@
 model,version,table,field,type,length,precision,scale,default
-pedsnet,v2,fact_relationship,domain_concept_id,integer,,,,
-pedsnet,v2,fact_relationship,domain_concept_id,integer,,,,
+pedsnet,v2,fact_relationship,domain_concept_id_1,integer,,,,
+pedsnet,v2,fact_relationship,domain_concept_id_2,integer,,,,
 pedsnet,v2,fact_relationship,fact_id_1,integer,,,,
 pedsnet,v2,fact_relationship,fact_id_2,integer,,,,
 pedsnet,v2,fact_relationship,relationship_concept_id,integer,,,,


### PR DESCRIPTION
Also fix pedsnet.v2.fact_relationship domain_concept_id schema fields
with _1 and _2 suffixes.

Fixes #67

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>