### PR TITLE
Remove i2b2_pedsnet v2 i2b2.id index

### DIFF
--- a/i2b2/i2b2_pedsnet/v2/metadata/indexes.csv
+++ b/i2b2/i2b2_pedsnet/v2/metadata/indexes.csv
@@ -1,2 +1,0 @@
-model,version,name,unique,table,field,order
-i2b2_pedsnet,v2,ix_i2b2_id,No,i2b2,id,asc


### PR DESCRIPTION
Erroneously referring to a field that doesn't exist.

Fixes #71

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>