### PR TITLE
Remove NOT NULL constraint from two vocab fields

### DIFF
--- a/pedsnet/v2.2/constraints/not_nulls.csv
+++ b/pedsnet/v2.2/constraints/not_nulls.csv
@@ -122,8 +122,6 @@ pedsnet,v2.2,not null,,visit_payer,visit_payer_id
 pedsnet,v2.2,not null,,vocabulary,vocabulary_concept_id
 pedsnet,v2.2,not null,,vocabulary,vocabulary_id
 pedsnet,v2.2,not null,,vocabulary,vocabulary_name
-pedsnet,v2.2,not null,,vocabulary,vocabulary_reference
-pedsnet,v2.2,not null,,vocabulary,vocabulary_version
 pedsnet,v2.2,not null,,measurement_organism,organism_concept_id
 pedsnet,v2.2,not null,,measurement_organism,measurement_id
 pedsnet,v2.2,not null,,measurement_organism,meas_organism_id

--- a/pedsnet/v2.2/definitions/vocabulary.csv
+++ b/pedsnet/v2.2/definitions/vocabulary.csv
@@ -2,5 +2,5 @@ model,version,table,field,required,ref_table,ref_field,description
 pedsnet,v2.2,vocabulary,vocabulary_concept_id,Yes,concept,concept_id,A foreign key that refers to a standard concept identifier in the Standardized Vocabularies for the vocabulary the Vocabulary record belongs to.
 pedsnet,v2.2,vocabulary,vocabulary_id,Yes,,,A unique identifier for each vocabulary.
 pedsnet,v2.2,vocabulary,vocabulary_name,Yes,,,"The name describing the vocabulary, for example ""SNOMED-CT"", ""ICD-9"", ""Visit"", etc. "
-pedsnet,v2.2,vocabulary,vocabulary_reference,Yes,,,"The name describing the vocabulary, for example ""SNOMED-CT"", ""ICD-9"", ""Visit"", etc. "
-pedsnet,v2.2,vocabulary,vocabulary_version,Yes,,,External reference to documentation or available download of the about the vocabulary.
+pedsnet,v2.2,vocabulary,vocabulary_reference,No,,,"The name describing the vocabulary, for example ""SNOMED-CT"", ""ICD-9"", ""Visit"", etc. "
+pedsnet,v2.2,vocabulary,vocabulary_version,No,,,External reference to documentation or available download of the about the vocabulary.

--- a/pedsnet/v2.2/models.csv
+++ b/pedsnet/v2.2/models.csv
@@ -1,2 +1,2 @@
 model,version,release_level,release_serial,label,url,description
-pedsnet,2.2.0,final,5,PEDSnet v2.2,http://pedsnet.info,
+pedsnet,2.2.0,final,6,PEDSnet v2.2,http://pedsnet.info,


### PR DESCRIPTION
Remove NOT NULL for vocabulary_reference and vocabulary_version in vocabulary.
Fixes #143.