### PR TITLE
Make circle.yml fork-friendly

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,8 @@ machine:
     BUILD_NUM: "${CIRCLE_BUILD_NUM}"
     COMMIT_SHA1: "${CIRCLE_SHA1}"
     BRANCH: "${CIRCLE_BRANCH}"
-    APP_NAME: "${CIRCLE_PROJECT_REPONAME}"
+    USER_NAME: "${CIRCLE_PROJECT_USERNAME}"
+    REPO_NAME: "${CIRCLE_PROJECT_REPONAME}"
     VERSION: "${CIRCLE_BRANCH}_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:0:8}"
     ARTIFACT_DIR: "${CIRCLE_ARTIFACTS}"
     DMSA_TEST_BRANCH: "master"
@@ -59,21 +60,29 @@ test:
     # Run the dms service locally using the data-models version being tested.
     # For pull requests, we need to do some fancy github API work...
     - if [ -z "${PULL_NUM}" ]; then 
-      docker run -d -p "8123:8123" --name dms dbhi/data-models -log error
+      docker run -d -p "8123:8123" --name dms dbhi/data-models
       -path /opt/repos -repo
-      "https://github.com/chop-dbhi/${APP_NAME}@${BRANCH}"; sleep 10; else
-      docker run -d -p "8123:8123" --name dms dbhi/data-models -log error
+      "https://github.com/${USER_NAME}/${REPO_NAME}@${BRANCH}" && sleep 10; else
+      docker run -d -p "8123:8123" --name dms dbhi/data-models
       -path /opt/repos -repo
-      "https://github.com/${PULL_USER}/${PULL_REPO}@$(curl -s https://api.github.com/repos/chop-dbhi/${APP_NAME}/pulls/${PULL_NUM} | jq --raw-output '.head.ref')";
+      "https://github.com/${PULL_USER}/${PULL_REPO}@$(curl -s https://api.github.com/repos/${USER_NAME}/${REPO_NAME}/pulls/${PULL_NUM} | jq --raw-output '.head.ref')" &&
       sleep 10; fi
+    # Simple verification of DMS
+    - curl -s http://127.0.0.1:8123/?format=json | grep --silent 'Data Models Service' || (docker logs dms; false)
     # Run the dmsa container locally.
-    - docker run -d -p "5000:80" --link dms:dms
+    - docker run -d -p "5000:80" --name dmsa --link dms:dms
       "dbhi/data-models-sqlalchemy:${DMSA_TEST_BRANCH/master/latest}" gunicorn
       --bind="0.0.0.0:80" --workers=4
       'dmsa.service:build_app("http://dms:8123/")'; sleep 10
+    # Simple verification of DMSA
+    - curl -s http://127.0.0.1:5000/ | grep --silent 'Data Models DDL and ERDs' || (docker logs dmsa; false)
     # Integration testing of the running container service.
     - cd ~/data-models-sqlalchemy; nosetests dmsa.tests.container_integration
     # Save DDL to artifact directory.
     - mkdir -p "${ARTIFACT_DIR}/ddl"
     - cd ~/data-models-sqlalchemy; python dmsa/tests/output_all_ddl.py
       "${ARTIFACT_DIR}/ddl/dms_${VERSION//\//_}_all_ddl.sql"
+    # Save DMS and DMSA logs to artifact directory.
+    - mkdir -p "${ARTIFACT_DIR}/log"
+    - docker logs dms > "${ARTIFACT_DIR}/log/dms.log" 2>&1
+    - docker logs dmsa > "${ARTIFACT_DIR}/log/dmsa.log" 2>&1


### PR DESCRIPTION
The main change is the introduction of USER_NAME
(CIRCLE_PROJECT_USERNAME) to avoid using the original repo's github
organization in URLs.

Other minor changes:

* dms runs with more verbose logging.
* Errors when starting dms or dmsa are caught directly.
* Gross failures of dms and dmsa containers are caught directly.
* If dms or dmsa do not respond, the container logs are dumped.
* dms and dmsa logs are saved as artifacts.

For PRs of forks to be tested, CircleCI advanced settings need to be
set:

* "Build forked pull requests" => "On"
* "Pass secrets to builds from forked pull requests" => "Off"

The latter may have no effect right now, but it seems needed for
safety.