### PR TITLE
Adding lab_site_mapping table

### DIFF
--- a/pedsnet/v3.7/constraints/not_nulls.csv
+++ b/pedsnet/v3.7/constraints/not_nulls.csv
@@ -160,3 +160,9 @@ pedsnet,v3.7,not null,,location_history,entity_id
 pedsnet,v3.7,not null,,location_history,relationship_type_concept_id
 pedsnet,v3.7,not null,,location_history,location_preferred_concept_id
 pedsnet,v3.7,not null,,hash_token,person_id
+pedsnet,v3.7,not null,,lab_site_mapping,pedsnet_lab_name
+pedsnet,v3.7,not null,,lab_site_mapping,pedsnet_loinc_code
+pedsnet,v3.7,not null,,lab_site_mapping,pedsnet_concept_id
+pedsnet,v3.7,not null,,lab_site_mapping,site_source_value
+pedsnet,v3.7,not null,,lab_site_mapping,site_loinc_code
+pedsnet,v3.7,not null,,lab_site_mapping,site_measurement_concept_id

--- a/pedsnet/v3.7/definitions/lab_site_mapping.csv
+++ b/pedsnet/v3.7/definitions/lab_site_mapping.csv
@@ -1,0 +1,7 @@
+model,version,table,field,required,ref_table,ref_field,description
+pedsnet,v3.7,lab_site_mapping,pedsnet_lab_name,yes,,,"The name of the PEDSnet lab. "
+pedsnet,v3.7,lab_site_mapping,pedsnet_loinc_code,yes,,,"The loinc code of the PEDSnet lab. "
+pedsnet,v3.7,lab_site_mapping,pedsnet_concept_id,yes,concept,concept_d,"The concept id of the PEDSnet lab. "
+pedsnet,v3.7,lab_site_mapping,site_source_value,yes,,,"The site measurement source value that corresponds to the PEDSnet lab."
+pedsnet,v3.7,lab_site_mapping,site_loinc_code,yes,,,"The site measurement loinc code that corresponds to the PEDSnet lab."
+pedsnet,v3.7,lab_site_mapping,site_measurement_concept_id,yes,concept,concept_id,"The site measurement concept id that corresponds to the PEDSnet lab."

--- a/pedsnet/v3.7/definitions/lab_site_mapping.csv
+++ b/pedsnet/v3.7/definitions/lab_site_mapping.csv
@@ -1,7 +1,7 @@
 model,version,table,field,required,ref_table,ref_field,description
-pedsnet,v3.7,lab_site_mapping,pedsnet_lab_name,yes,,,"The name of the PEDSnet lab. "
-pedsnet,v3.7,lab_site_mapping,pedsnet_loinc_code,yes,,,"The loinc code of the PEDSnet lab. "
-pedsnet,v3.7,lab_site_mapping,pedsnet_concept_id,yes,concept,concept_d,"The concept id of the PEDSnet lab. "
-pedsnet,v3.7,lab_site_mapping,site_source_value,yes,,,"The site measurement source value that corresponds to the PEDSnet lab."
-pedsnet,v3.7,lab_site_mapping,site_loinc_code,yes,,,"The site measurement loinc code that corresponds to the PEDSnet lab."
-pedsnet,v3.7,lab_site_mapping,site_measurement_concept_id,yes,concept,concept_id,"The site measurement concept id that corresponds to the PEDSnet lab."
+pedsnet,v3.7,lab_site_mapping,pedsnet_lab_name,Yes,,,"The name of the PEDSnet lab. "
+pedsnet,v3.7,lab_site_mapping,pedsnet_loinc_code,Yes,,,"The loinc code of the PEDSnet lab. "
+pedsnet,v3.7,lab_site_mapping,pedsnet_concept_id,Yes,concept,concept_d,"The concept id of the PEDSnet lab. "
+pedsnet,v3.7,lab_site_mapping,site_source_value,Yes,,,"The site measurement source value that corresponds to the PEDSnet lab."
+pedsnet,v3.7,lab_site_mapping,site_loinc_code,Yes,,,"The site measurement loinc code that corresponds to the PEDSnet lab."
+pedsnet,v3.7,lab_site_mapping,site_measurement_concept_id,Yes,concept,concept_id,"The site measurement concept id that corresponds to the PEDSnet lab."

--- a/pedsnet/v3.7/definitions/tables.csv
+++ b/pedsnet/v3.7/definitions/tables.csv
@@ -32,4 +32,4 @@ pedsnet,v3.7,immunization,The immunization domain captures immunization records.
 pedsnet,v3.7,device_exposure,The Device domain captures information about a person's exposure to a foreign physical object or instrument which is used for diagnostic or therapeutic purposes through a mechanism beyond chemical action.
 pedsnet,v3.7,location_history,"The 'Location_History' domain is intended to store historical location information for various domains persons, providers and care_sites."
 pedsnet,v3.7,hash_token,"The 'Hash_Token' domain is intended to store encrypted and keyed secure hash tokens that are used to match patient records across DataMarts using privacy-preserving record linkage methods. This table requirement comes from the PCORnet data model."
-
+pedsnet,v3.7,lab_site_mapping,"The 'Lab Site Mapping' table is intended to store local site mappings to the standard PEDSnet loinc codes."

--- a/pedsnet/v3.7/models.csv
+++ b/pedsnet/v3.7/models.csv
@@ -1,2 +1,2 @@
 model,version,release_level,release_serial,label,url,description
-pedsnet,3.7.0,beta,1,PEDSnet v3.7,http://pedsnet.info,
+pedsnet,3.7.0,beta,2,PEDSnet v3.7,http://pedsnet.info,

--- a/pedsnet/v3.7/references.csv
+++ b/pedsnet/v3.7/references.csv
@@ -144,3 +144,5 @@ pedsnet,v3.7,location_history,entity_id,person,person_id,fpk_loc_hist_person
 pedsnet,v3.7,location_history,relationship_type_concept_id,concept,concept_id,fpk_loc_hist_type
 pedsnet,v3.7,location_history,location_preferred_concept_id,concept,concept_id,fpk_loc_hist_pref
 pedsnet,v3.7,hash_token,person_id,person,person_id,fpk_hash_token_person
+pedsnet,v3.7,lab_site_mapping,pedsnet_concept_id,concept,concept_id,fpk_pedsnet_concept
+pedsnet,v3.7,lab_site_mapping,site_measurement_concept_id,concept,concept_id,fpk_site_measurement_concept

--- a/pedsnet/v3.7/schema/lab_site_mappng.csv
+++ b/pedsnet/v3.7/schema/lab_site_mappng.csv
@@ -1,0 +1,7 @@
+model,version,table,field,type,length,precision,scale,default
+pedsnet,v3.7,lab_site_mapping,pedsnet_lab_name,string,,,,
+pedsnet,v3.7,lab_site_mapping,pedsnet_loinc_code,string,,,,
+pedsnet,v3.7,lab_site_mapping,pedsnet_concept_id,integer,,,,
+pedsnet,v3.7,lab_site_mapping,site_source_value,string,,,,
+pedsnet,v3.7,lab_site_mapping,site_loinc_code,string,,,,
+pedsnet,v3.7,lab_site_mapping,site_measurement_concept_id,integer,,,,


### PR DESCRIPTION
This will support basic checking of the site lab mappings table that will be submitted to the DCC along with the traditional submission files.