### PR TITLE
FK name < 30 characters

### DIFF
--- a/pedsnet/v4.6/models.csv
+++ b/pedsnet/v4.6/models.csv
@@ -1,2 +1,2 @@
 model,version,release_level,release_serial,label,url,description
-pedsnet,4.6.0,alpha,3,PEDSnet v4.6,http://pedsnet.info,
+pedsnet,4.6.0,alpha,4,PEDSnet v4.6,http://pedsnet.info,

--- a/pedsnet/v4.6/references.csv
+++ b/pedsnet/v4.6/references.csv
@@ -150,5 +150,5 @@ pedsnet,v4.6,hash_token,person_id,person,person_id,fpk_hash_token_person
 pedsnet,v4.6,lab_site_mapping,pedsnet_concept_id,concept,concept_id,fpk_pedsnet_concept
 pedsnet,v4.6,lab_site_mapping,site_measurement_concept_id,concept,concept_id,fpk_site_measurement_concept
 pedsnet,v4.6,location,country_concept_id,concept,concept_id,fpk_location_country_concept
-pedsnet,v4.6,specialty,specialty_concept_id,concept,concept_id,fpk_specialty_specialty_concept
+pedsnet,v4.6,specialty,specialty_concept_id,concept,concept_id,fpk_specialty_spec_concept
 pedsnet,v4.6,specialty,entity_type_concept_id,concept,concept_id,fpk_specialty_entity_type


### PR DESCRIPTION
Change specialty FK from fpk_specialty_specialty_concept to fpk_specialty_spec_concept so that it is less than 30 characters. Fixes Oracle bug - oracle requires objects to be less than 30 characters.



